### PR TITLE
upgrade workflow runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,13 +10,16 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       max-parallel: 4
       matrix:
         include:
-          - python: 3.11.1
-            django: 4.1.6
+          - python: 3.11.11
+            django: 5.2.0
+            djangorestframework: 3.16.0
+          - python: 3.11.11
+            django: 4.1.13
             djangorestframework: 3.14.0
           - python: 3.9.16
             django: 3.2.17
@@ -24,16 +27,10 @@ jobs:
           - python: 3.7.15
             django: 2.2.28
             djangorestframework: 3.9.4
-          - python: 3.5.10
-            django: 1.11.29
-            djangorestframework: 3.9.4
-          - python: 2.7.18
-            django: 1.8.19
-            djangorestframework: 3.6.4
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Install Dependencies
@@ -41,7 +38,7 @@ jobs:
           python -m pip 
           install --upgrade 
           pip 
-          'setuptools<56'
+          'setuptools<58'
           wheel 
           flake8 
           'Django==${{ matrix.django }}'

--- a/setup.py
+++ b/setup.py
@@ -34,12 +34,6 @@ setup(
         'Environment :: Web Environment',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -47,16 +41,13 @@ setup(
         'Programming Language :: Python :: 3.11',
 
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
+        'Framework :: Django :: 4.2',
 
         'Topic :: Text Processing :: Markup :: HTML',
     ],
@@ -65,6 +56,6 @@ setup(
         'djangorestframework'
     ],
     setup_requires=[
-        'setuptools_scm',
+        'setuptools_scm<8',
     ],
 )


### PR DESCRIPTION
GitHub Actions runners based on Ubuntu 18.04 and 20.04 are no longer available.
That also means that older Python versions can't be installed with the default action.

This PR upgrades the runner to a supported version, and updates the tools somewhat.